### PR TITLE
feat/clone client

### DIFF
--- a/examples/rpc_callee_with_cryptosign.rs
+++ b/examples/rpc_callee_with_cryptosign.rs
@@ -1,10 +1,11 @@
 use std::error::Error;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use lazy_static::*;
 
 use wamp_async::{
-    Client, ClientConfig, ClientState, SerializerType, WampArgs, WampError, WampKwArgs,
+    Client, ClientConfig, ClientState, SerializerType, WampArgs, WampError, WampKwArgs, RegistrationOptions, InvokeOption
 };
 
 lazy_static! {
@@ -12,7 +13,7 @@ lazy_static! {
 }
 
 // Simply return the rpc arguments
-async fn echo(
+async fn echo<'a>(
     args: Option<WampArgs>,
     kwargs: Option<WampKwArgs>,
 ) -> Result<(Option<WampArgs>, Option<WampKwArgs>), WampError> {
@@ -98,7 +99,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ).await?;
 
     // Register our functions to a uri
-    let echo_rpc_id = client.register("peer.echo", echo).await?;
+    let options = RegistrationOptions::invoke(InvokeOption::Last);
+    let echo_rpc_id = client.register_with_options("peer.echo", echo, options).await?;
     let strict_echo_rpc_id = client.register("peer.strict_echo", strict_echo).await?;
 
     println!("Waiting for 'peer.echo' to be called at least 4 times");

--- a/src/client.rs
+++ b/src/client.rs
@@ -647,7 +647,7 @@ impl<'a> Client<'a> {
     pub async fn register_with_client<T, F, Fut>(&self, uri: T, func_ptr: F, options: RegistrationOptions) -> Result<WampId, WampError>
     where
         T: AsRef<str>,
-        F: Fn(Client, Option<WampArgs>, Option<WampKwArgs>) -> Fut + Send + Sync + 'a,
+        F: Fn(Client<'a>, Option<WampArgs>, Option<WampKwArgs>) -> Fut + Send + Sync + 'a,
         Fut: Future<Output = Result<(Option<WampArgs>, Option<WampKwArgs>), WampError>> + Send + 'a,
     {
         // Send the request

--- a/src/client.rs
+++ b/src/client.rs
@@ -644,7 +644,7 @@ impl<'a> Client<'a> {
         Ok(rpc_id)
     }
 
-    pub async fn register_with_client<T, F, Fut>(&self, uri: T, func_ptr: F, options: Option<RegistrationOptions>) -> Result<WampId, WampError>
+    pub async fn register_with_client<T, F, Fut>(&self, uri: T, func_ptr: F, options: RegistrationOptions) -> Result<WampId, WampError>
     where
         T: AsRef<str>,
         F: Fn(Client, Option<WampArgs>, Option<WampKwArgs>) -> Fut + Send + Sync + 'a,
@@ -652,11 +652,6 @@ impl<'a> Client<'a> {
     {
         // Send the request
         let (res, result) = oneshot::channel();
-
-        let my_options = match options {
-            Some(o) => o,
-            None => RegistrationOptions::default()
-        };
 
         let copy_client = self.clone();
         if let Err(e) = self.ctl_channel.send(Request::Register {

--- a/src/client.rs
+++ b/src/client.rs
@@ -658,7 +658,7 @@ impl<'a> Client<'a> {
             uri: uri.as_ref().to_string(),
             res,
             func_ptr: Box::new(move |a, k| Box::pin(func_ptr(copy_client.to_owned(), a, k))),
-            options: match my_options.get_dict() {
+            options: match options.get_dict() {
                 Some(dict) => dict,
                 None => WampDict::new(),
             },

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,8 +12,6 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::error::*;
 
-use crate::message::Msg;
-
 pub(crate) const DEFAULT_AGENT_STR: &str =
     concat!(env!("CARGO_PKG_NAME"), "_rs-", env!("CARGO_PKG_VERSION"));
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,6 +12,8 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::error::*;
 
+use crate::message::Msg;
+
 pub(crate) const DEFAULT_AGENT_STR: &str =
     concat!(env!("CARGO_PKG_NAME"), "_rs-", env!("CARGO_PKG_VERSION"));
 
@@ -59,12 +61,46 @@ pub type WampList = Vec<Arg>;
 ///
 /// Implementation note: we currently use `serde_json::Value`, which is
 /// suboptimal when you want to use MsgPack and pass binary data.
+
 pub type WampPayloadValue = serde_json::Value;
 /// Unnamed WAMP argument list
 pub type WampArgs = Vec<WampPayloadValue>;
 /// Named WAMP argument map
 pub type WampKwArgs = serde_json::Map<String, WampPayloadValue>;
 
+pub type WampResult = Result<(Option<WampArgs>, Option<WampKwArgs>), WampError>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceErrorDetails {
+    pub args: WampList,
+    pub kwargs: WampDict,
+}
+
+impl ServiceErrorDetails {
+    pub fn new(args: Option<WampList>, kwargs: Option<WampDict>) -> Self {
+        let a = match args {
+            Some(d) => d,
+            None => vec![]
+        };
+
+        let k = match kwargs {
+            Some(d) => d,
+            None => WampDict::default()
+        };
+
+        ServiceErrorDetails { args: a, kwargs: k}
+    }
+    pub fn get_args(&self) -> Result<WampArgs, WampError> {
+        try_into_args(&self.args)
+    }
+
+    pub fn get_kwargs(&self) -> Result<WampKwArgs, WampError> {
+        try_into_kwargs(&self.kwargs)
+    }
+
+    pub fn get_error_message(&self) -> () {
+    }
+}
 
 #[derive(Copy, Clone)]
 pub struct CryptoSign {

--- a/src/common.rs
+++ b/src/common.rs
@@ -71,12 +71,12 @@ pub type WampKwArgs = serde_json::Map<String, WampPayloadValue>;
 pub type WampResult = Result<(Option<WampArgs>, Option<WampKwArgs>), WampError>;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ServiceErrorDetails {
+pub struct ApplicationErrorDetails {
     pub args: WampList,
     pub kwargs: WampDict,
 }
 
-impl ServiceErrorDetails {
+impl ApplicationErrorDetails {
     pub fn new(args: Option<WampList>, kwargs: Option<WampDict>) -> Self {
         let a = match args {
             Some(d) => d,
@@ -88,7 +88,7 @@ impl ServiceErrorDetails {
             None => WampDict::default()
         };
 
-        ServiceErrorDetails { args: a, kwargs: k}
+        ApplicationErrorDetails { args: a, kwargs: k}
     }
     pub fn get_args(&self) -> Result<WampArgs, WampError> {
         try_into_args(&self.args)

--- a/src/core/send.rs
+++ b/src/core/send.rs
@@ -375,14 +375,14 @@ pub async fn invoke_yield(
         },
         Err(e) => {
             let uri = match &e {
-                WampError::ServiceError(c, d) => {
+                WampError::ApplicationError(c, d) => {
                     c.to_owned()
                 },
                 _ => "wamp.async.rs.rpc.failed".to_string()
             };
 
             let service_details = match &e {
-                WampError::ServiceError(_c, d) => {
+                WampError::ApplicationError(_c, d) => {
                     Some(d.to_owned())
                 },
                 _ => None

--- a/src/core/send.rs
+++ b/src/core/send.rs
@@ -375,7 +375,7 @@ pub async fn invoke_yield(
         },
         Err(e) => {
             let uri = match &e {
-                WampError::ApplicationError(c, d) => {
+                WampError::ApplicationError(c, _d) => {
                     c.to_owned()
                 },
                 _ => "wamp.async.rs.rpc.failed".to_string()

--- a/src/core/send.rs
+++ b/src/core/send.rs
@@ -84,7 +84,7 @@ pub async fn join_realm(
         if role.has_features() {
             roledict.insert("features".to_owned(), Arg::Dict(role.get_features()));
         }
-        
+
         client_roles.insert(String::from(role.to_str()), Arg::Dict(roledict.clone()));
     }
     details.insert("roles".to_owned(), Arg::Dict(client_roles));
@@ -373,13 +373,39 @@ pub async fn invoke_yield(
             arguments,
             arguments_kw,
         },
-        Err(e) => Msg::Error {
-            typ: INVOCATION_ID as WampInteger,
-            request,
-            details: WampDict::new(),
-            error: "wamp.async.rs.rpc.failed".to_string(),
-            arguments: Some(vec![format!("{:?}", e).into()]),
-            arguments_kw: None,
+        Err(e) => {
+            let uri = match &e {
+                WampError::ServiceError(c, d) => {
+                    c.to_owned()
+                },
+                _ => "wamp.async.rs.rpc.failed".to_string()
+            };
+
+            let service_details = match &e {
+                WampError::ServiceError(_c, d) => {
+                    Some(d.to_owned())
+                },
+                _ => None
+            };
+
+            let (arguments, kwargs): (Vec<WampPayloadValue>, WampKwArgs) = match service_details {
+                Some(d) => {
+                    (d.get_args().unwrap(), d.get_kwargs().unwrap())
+                },
+                None =>
+                {
+                    (vec![format!("{:?}", e).into()], WampKwArgs::new())
+                }
+            };
+
+            Msg::Error {
+                typ: INVOCATION_ID as WampInteger,
+                request,
+                details: WampDict::new(),
+                error: uri,
+                arguments: Some(arguments),
+                arguments_kw: Some(kwargs),
+            }
         },
     };
     if core.send(&msg).await.is_err() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,8 +52,8 @@ quick_error! {
             display("The server returned an error: {} {:?}", uri, details)
         }
         /// The server sent us an Error message
-        ServiceError(uri: String, details: ServiceErrorDetails) {
-            context(uri: String, details: ServiceErrorDetails) -> (uri, details)
+        ApplicationError(uri: String, details: ApplicationErrorDetails) {
+            context(uri: String, details: ApplicationErrorDetails) -> (uri, details)
             display("The server returned an error: {} {:?}", uri, details)
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,5 +51,10 @@ quick_error! {
             context(uri: String, details: WampDict) -> (uri, details)
             display("The server returned an error: {} {:?}", uri, details)
         }
+        /// The server sent us an Error message
+        ServiceError(uri: String, details: ServiceErrorDetails) {
+            context(uri: String, details: ServiceErrorDetails) -> (uri, details)
+            display("The server returned an error: {} {:?}", uri, details)
+        }
     }
 }

--- a/src/options/registration.rs
+++ b/src/options/registration.rs
@@ -37,12 +37,12 @@ impl RegistrationOptionItem {
 
 /// Add base OptionBuilder functionality
 impl OptionBuilder for RegistrationOptionItem {
-    /// Build a new SubscriptionOptionItem from a provided Option<WampDict>
+    /// Build a new RegistrationOptionItem from a provided Option<WampDict>
     fn create(options: Option<WampDict>) -> Self where Self: OptionBuilder + Sized {
         Self(options)
     }
 
-    /// Return the WampDict being operated on and stored by SubscriptionOptionItem
+    /// Return the WampDict being operated on and stored by RegistrationOptionItem
     fn get_dict(&self) -> Option<WampDict> {
         self.0.clone()
     }


### PR DESCRIPTION
- feat: added ability to clone client for use in subscription handlers and rpc handlers
- now lets you return a better error to clients
- now lets you return a better error to clients
- now properly cloning core_res channel
- git rid of warnings
- changed client interface
- corrected typo cause im tired
- fixed another silly bug
